### PR TITLE
chore: rename crate to bls_bulletproofs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,12 @@
 [package]
-name = "sn_bulletproofs"
-# Before doing a release:
-# - update version field 
-# - update html_root_url
-# - update CHANGELOG
+name = "bls_bulletproofs"
 version = "0.1.0"
 authors = ["Cathie Yun <cathieyun@gmail.com>", 
            "Henry de Valence <hdevalence@hdevalence.ca>",
            "Oleg Andreev <oleganza@gmail.com>"]
 readme = "README.md"
 license = "MIT"
-repository = "https://github.com/maidsafe/sn_bulletproofs"
+repository = "https://github.com/maidsafe/bls_bulletproofs"
 categories = ["cryptography"]
 keywords = ["cryptography", "crypto", "ristretto", "zero-knowledge", "bulletproofs"]
 description = "A pure-Rust implementation of Bulletproofs using Ristretto"
@@ -43,7 +39,6 @@ yoloproofs = []
 std = ["thiserror"]
 nightly = ["subtle/nightly", "clear_on_drop/nightly"]
 docs = ["nightly"]
-
 
 [[test]]
 name = "range_proof"


### PR DESCRIPTION
Yesterday we renamed this crate from blst_bulletproofs to sn_bulletproofs, but later we decided it
would be independent of Safe, so we'll rename again. We lose the 'sn' prefix in favour of 'bls',
which drops the 't' from the original name, since that's a specific implementation detail of the
original repository, which our fork has now diverged from. We also have other repos/crates that use
this 'bls' prefix, so it brings it in line with those.