### PR TITLE
chore: upgrade blstrs to 0.6.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ description = "A pure-Rust implementation of Bulletproofs using Ristretto"
 edition = "2018"
 
 [dependencies]
-blstrs = "0.4.2"
+blstrs = "0.6.1"
 subtle = { version = "2.4.1", default-features = false }
 sha3 = { version = "0.9.1", default-features = false }
 rand_chacha = "0.3" # used as a seedable rng in GeneratorsxChain
@@ -25,7 +25,7 @@ serde_derive = { version = "1", default-features = false }
 thiserror = { version = "1", optional = true }
 merlin = { version = "3", default-features = false }
 clear_on_drop = { version = "0.2", default-features = false }
-group = "0.11.0"
+group = "0.12.0"
 
 [dev-dependencies]
 hex = "0.3"


### PR DESCRIPTION
This should enable upgrading `blsttc` to 8.0.1 in `sn_dbc`. The `blsttc` crate has upgraded `blstrs` to 0.6.1, so this gets both crates on the same version.

The `bls_ringct` crate can then upgrade to this new version of `bls_bulletproofs` and also be on the same version of `blstrs`. This will mean there will only be one version of `blstrs` in the dependency graph.

It was necessary to upgrade `group` to 0.12.0 as part of this change.